### PR TITLE
Exclude data source checking for succesful compiling by Maven

### DIFF
--- a/src/main/java/nl/stackftp/StackftpApplication.java
+++ b/src/main/java/nl/stackftp/StackftpApplication.java
@@ -1,9 +1,13 @@
 package nl.stackftp;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
 @SpringBootApplication
+@EnableAutoConfiguration(exclude={DataSourceAutoConfiguration.class})
+
 public class StackftpApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
Exclude data source checking for succesful compiling by Maven

Maven would throw an error when there's no data source provided in the configuration.
